### PR TITLE
Remove Int as a builtin type

### DIFF
--- a/src/JOSPreDefinitions/BuiltInTypes.jl
+++ b/src/JOSPreDefinitions/BuiltInTypes.jl
@@ -14,8 +14,6 @@ export _Exception, _TypeException, _IO,
 @defbuiltin _Int64(Int64)
 @defbuiltin _Int128(Int128)
 
-@defbuiltin _Int(Int)
-
 @defbuiltin _Bool(Bool)
 
 @defbuiltin _Char(Char)

--- a/src/JOSPreDefinitions/BuiltInTypes.jl
+++ b/src/JOSPreDefinitions/BuiltInTypes.jl
@@ -8,11 +8,17 @@ export _Exception, _TypeException, _IO,
 @defbuiltin _TypeException(Type{Exception})
 @defbuiltin _IO(IO)
 
+@defclass(_Int, [Top], [], metaclass=BuiltInClass)
+
 @defbuiltin _Int8(Int8)
 @defbuiltin _Int16(Int16)
-@defbuiltin _Int32(Int32)
-@defbuiltin _Int64(Int64)
 @defbuiltin _Int128(Int128)
+
+@defclass(_Int32, [_Int], [], metaclass=BuiltInClass)
+class_of(instance::Int32) = _Int32
+
+@defclass(_Int64, [_Int], [], metaclass=BuiltInClass)
+class_of(instance::Int64) = _Int64
 
 @defbuiltin _Bool(Bool)
 

--- a/test/test_built_in_classes.jl
+++ b/test/test_built_in_classes.jl
@@ -3,8 +3,8 @@ using Test
 
 @testset "Built-In Classes" begin
     @testset "Print object" begin
-        result = @capture_out show(class_of(1))
-        @test result == "<BuiltInClass _Int>"
+        result = @capture_out show(class_of(Int64(1)))
+        @test result == "<BuiltInClass _Int64>"
 
         result = @capture_out show(class_of("Foo"))
         @test result == "<BuiltInClass _String>"


### PR DESCRIPTION
The Int type in Julia is a aliases to either Int64 or Int32 depending on computer architecture. And thus, when trying to define the class_of which receives Int we are actually either defining for Int64 or Int32 and thus redefining it, giving out an warning during precompilation